### PR TITLE
Change the behaviour of generated getter and setter

### DIFF
--- a/lib/spinning_cursor.rb
+++ b/lib/spinning_cursor.rb
@@ -17,8 +17,8 @@ module SpinningCursor
     end
 
     @parsed = Parser.new(block)
-    @cursor = Cursor.new(@parsed.banner nil)
-    @curs   = Thread.new { @cursor.spin(@parsed.type(nil), @parsed.delay(nil)) }
+    @cursor = Cursor.new(@parsed.banner)
+    @curs   = Thread.new { @cursor.spin(@parsed.type, @parsed.delay) }
     @start  = @finish = @elapsed = nil
 
     if @parsed.action.nil?
@@ -51,7 +51,7 @@ module SpinningCursor
       # when cursor is actually running.
       @cursor = nil
       reset_line
-      puts (@parsed.message nil)
+      puts @parsed.message
       # Set parsed to nil so set_message method only works
       # when cursor is actually running.
       @parsed = nil

--- a/lib/spinning_cursor/parser.rb
+++ b/lib/spinning_cursor/parser.rb
@@ -32,10 +32,12 @@ module SpinningCursor
     #
     # Getters and setters for +banner+, +type+ and +message+
     # attributes.
-    # Note:: for getting, pass nil e.g. <tt>banner nil</tt>
-    #
+    # Note:: for getting use method without arguments
+    #            e.g. <tt>banner</tt>
+    #        for setting use method with arguments
+    #            e.g. <tt>banner "my banner"</tt>.
     %w[banner type message delay].each do |method|
-      define_method(method) do |arg|
+      define_method(method) do |arg=nil|
         var = "@#{method}"
         return instance_variable_get(var) if arg.nil?
         instance_variable_set(var, arg)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -7,7 +7,7 @@ class TestSpinningCursorParser < Test::Unit::TestCase
         "Banner"
       end
       parser = SpinningCursor::Parser.new Proc.new { banner banner_text }
-      assert_equal banner_text, (parser.banner nil)
+      assert_equal banner_text, parser.banner
     end
   end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -18,16 +18,16 @@ class TestSpinningCursorParser < Test::Unit::TestCase
 
     should "act as getters and setters" do
       @parser.banner "a new banner"
-      assert_equal "a new banner", (@parser.banner nil)
+      assert_equal "a new banner", @parser.banner
 
       @parser.type :dots
-      assert_equal :dots, (@parser.type nil)
+      assert_equal :dots, @parser.type
 
       @parser.message "a message"
-      assert_equal "a message", (@parser.message nil)
+      assert_equal "a message", @parser.message
 
       @parser.delay 5
-      assert_equal 5, (@parser.delay nil)
+      assert_equal 5, @parser.delay
 
       proc = Proc.new { }
       @parser.action &proc


### PR DESCRIPTION
Perhaps a matter of "taste".
I don't like passing 'nil' to have the getter behaviour.
It seams like I'm setting the banner to "nil".
In most code we see just the method (without arguments).

So, instead of

``` ruby
@parser.banner nil
```

just

``` ruby
@parser.banner
```

and it will do the job.

But, if this is not your taste, feel free to drop unmerged this pull request.

(Perhaps there's a better way to do it).
