### PR TITLE
More generic "spinner" using the new "cycle_through" and faster tests

### DIFF
--- a/lib/spinning_cursor/cursor.rb
+++ b/lib/spinning_cursor/cursor.rb
@@ -64,13 +64,11 @@ module SpinningCursor
     #
     def spinner(delay = 0.5)
       spinners = ['|', '/', '-', '\\']
-      i = 0
-      loop do
+      spinners.cycle do |spinner|
         print " " unless @banner.empty?
-        print spinners[i % 4]
+        print spinner
         sleep delay
         SpinningCursor.reset_line @banner
-        i += 1
       end
     end
   end

--- a/lib/spinning_cursor/cursor.rb
+++ b/lib/spinning_cursor/cursor.rb
@@ -46,16 +46,12 @@ module SpinningCursor
     # Prints three dots and clears the line
     #
     def dots(delay = 1)
-      i = 1
-      loop do
+      dots = ['.', '..', '...', '']
+      dots.cycle do |dot|
+        print " " unless @banner.empty?
+        print dot
         sleep delay
-        if i % 4 == 0
-          SpinningCursor.reset_line @banner
-          i += 1
-          next
-        end
-        i += 1
-        print "."
+        SpinningCursor.reset_line @banner
       end
     end
 

--- a/lib/spinning_cursor/cursor.rb
+++ b/lib/spinning_cursor/cursor.rb
@@ -46,23 +46,20 @@ module SpinningCursor
     # Prints three dots and clears the line
     #
     def dots(delay = 1)
-      dots = ['.', '..', '...', '']
-      dots.cycle do |dot|
-        print " " unless @banner.empty?
-        print dot
-        sleep delay
-        SpinningCursor.reset_line @banner
-      end
+      cycle_through ['.', '..', '...', ''], delay
     end
 
     #
     # Cycles through '|', '/', '-', '\', resembling a spinning cursor
     #
     def spinner(delay = 0.5)
-      spinners = ['|', '/', '-', '\\']
-      spinners.cycle do |spinner|
+      cycle_through ['|', '/', '-', '\\'], delay
+    end
+
+    def cycle_through(chars, delay)
+      chars.cycle do |char|
         print " " unless @banner.empty?
-        print spinner
+        print char
         sleep delay
         SpinningCursor.reset_line @banner
       end

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -5,10 +5,10 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
     should "reset line after printing three dots" do
       capture_stdout do |out|
         dots = Thread.new do
-          SpinningCursor::Cursor.new("").spin :dots
+          SpinningCursor::Cursor.new("").spin :dots, 0.2
         end
-        # "" -> "." -> ".." -> "..." -> "" -- so 5 seconds for each cycle
-        sleep 5
+        # "." -> ".." -> "..." -> "" -> "." -- so 1 seconds for each cycle
+        sleep 1
         dots.kill
         # \r\e[0K is move cursor to the start of the line and clear line
         # in bash
@@ -19,12 +19,12 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
     should "change 'frames' with correct delay" do
       capture_stdout do |out|
         dots = Thread.new do
-          SpinningCursor::Cursor.new("").spin :dots, 1
+          SpinningCursor::Cursor.new("").spin :dots, 0.5
         end
         # slight delay to get things started
         sleep 0.1
         assert_equal ".", out.string
-        sleep 1
+        sleep 0.5
         assert_equal ".\r\e[0K..", out.string
         # don't need to go through the whole thing, otherwise test will take
         # too long
@@ -37,22 +37,22 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
     should "cycle through correctly" do
       capture_stdout do |out|
         spinner = Thread.new do
-          SpinningCursor::Cursor.new("").spin :spinner, 0.5
+          SpinningCursor::Cursor.new("").spin :spinner, 0.2
         end
         # slight delay to get things started
         sleep 0.1
         assert_equal "|", out.string
         buffer = "|\r\e[0K"
-        sleep 0.5
+        sleep 0.2
         assert_equal "#{buffer}/", out.string
         buffer += "/\r\e[0K"
-        sleep 0.5
+        sleep 0.2
         assert_equal "#{buffer}-", out.string
         buffer += "-\r\e[0K"
-        sleep 0.5
+        sleep 0.2
         assert_equal "#{buffer}\\", out.string
         buffer += "\\\r\e[0K"
-        sleep 0.5
+        sleep 0.2
         assert_equal "#{buffer}|", out.string
         spinner.kill
       end
@@ -61,13 +61,13 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
     should "changes 'frames' with correct delay" do
       capture_stdout do |out|
         spinner = Thread.new do
-          SpinningCursor::Cursor.new("").spin :spinner, 1 # double the speed
+          SpinningCursor::Cursor.new("").spin :spinner, 0.5 # 4x the speed
         end
         sleep 0.1
         assert_equal "|", out.string
         buffer = "|\r\e[0K"
-        sleep 1
-        # next frame after 1 second
+        sleep 0.5
+        # next frame after 0.5 second
         assert_equal "#{buffer}/", out.string
         # don't need to go through the whole thing, otherwise test will take
         # too long

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -23,9 +23,9 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
         end
         # slight delay to get things started
         sleep 0.1
-        assert_equal "", out.string
-        sleep 1
         assert_equal ".", out.string
+        sleep 1
+        assert_equal ".\r\e[0K..", out.string
         # don't need to go through the whole thing, otherwise test will take
         # too long
         dots.kill

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -19,12 +19,12 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
     should "change 'frames' with correct delay" do
       capture_stdout do |out|
         dots = Thread.new do
-          SpinningCursor::Cursor.new("").spin :dots, 2
+          SpinningCursor::Cursor.new("").spin :dots, 1
         end
         # slight delay to get things started
         sleep 0.1
         assert_equal "", out.string
-        sleep 2
+        sleep 1
         assert_equal ".", out.string
         # don't need to go through the whole thing, otherwise test will take
         # too long

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -12,7 +12,7 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
         dots.kill
         # \r\e[0K is move cursor to the start of the line and clear line
         # in bash
-        assert_equal "...\r\e[0K", out.string
+        assert_equal ".\r\e[0K..\r\e[0K...\r\e[0K\r\e[0K.", out.string
       end
     end
 

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -37,7 +37,7 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
     should "cycle through correctly" do
       capture_stdout do |out|
         spinner = Thread.new do
-          SpinningCursor::Cursor.new("").spin :spinner
+          SpinningCursor::Cursor.new("").spin :spinner, 0.5
         end
         # slight delay to get things started
         sleep 0.1

--- a/test/test_spinning_cursor.rb
+++ b/test/test_spinning_cursor.rb
@@ -6,7 +6,7 @@ class TestSpinningCursor < Test::Unit::TestCase
       # Hide any output
       capture_stdout do |out|
         SpinningCursor.start do
-          action { sleep 1 }
+          action { sleep 0.1 }
         end
         # Give it some time to abort
         assert_equal false, SpinningCursor.alive?
@@ -31,7 +31,7 @@ class TestSpinningCursor < Test::Unit::TestCase
         SpinningCursor.start do
           banner "no action block"
         end
-        sleep 2
+        sleep 0.5
         assert_equal true, SpinningCursor.alive?
         SpinningCursor.stop
         sleep 0.1
@@ -85,13 +85,14 @@ class TestSpinningCursor < Test::Unit::TestCase
     should "allow you to change the banner" do
       capture_stdout do |out|
         SpinningCursor.start do
+          delay 0.2
           action do
             # Have to give it time to print the banners
             sleep 0.1
             assert_equal true, (out.string.include? "Loading")
             sleep 0.1
             SpinningCursor.set_banner "Finishing up"
-            sleep 0.5
+            sleep 0.2
             assert_equal true, (out.string.include? "Finishing up")
             sleep 0.1
           end
@@ -104,16 +105,16 @@ class TestSpinningCursor < Test::Unit::TestCase
     should "(without a block) return similar timing values" do
       capture_stdout do |out|
         SpinningCursor.start
-        sleep 1.5
+        sleep 0.2
         result = SpinningCursor.stop
         timing_1 = result[:finished] - result[:started]
 
         SpinningCursor.start
-        sleep 1.5
+        sleep 0.2
         result = SpinningCursor.stop
         timing_2 = result[:finished] - result[:started]
 
-        assert_equal timing_1.round, timing_2.round,
+        assert_equal (timing_1*10).round, (timing_2*10).round,
         "t1 #{timing_1} and t2 #{timing_2} should be equal"
       end
     end
@@ -123,7 +124,7 @@ class TestSpinningCursor < Test::Unit::TestCase
         result =
         SpinningCursor.start do
           action do
-            sleep 1.5
+            sleep 0.2
           end
         end
         timing_1 = result[:finished] - result[:started]
@@ -131,12 +132,12 @@ class TestSpinningCursor < Test::Unit::TestCase
         result =
         SpinningCursor.start do
           action do
-            sleep 1.5
+            sleep 0.2
           end
         end
         timing_2 = result[:finished] - result[:started]
 
-        assert_equal timing_1.round, timing_2.round,
+        assert_equal (timing_1*10).round, (timing_2*10).round,
         "t1 #{timing_1} and t2 #{timing_2} should be equal"
       end
     end


### PR DESCRIPTION
As I'm digging into the code I keep running the tests frequently and they were lasting at least 20 seconds to run.
I just cut some fat and now they run in ~6 seconds.

The other thing of this pull request is to make the spinner methods more generic.

Now to create your custom spinner you just have to 

``` ruby
class SpinningCursor::Cursor
    def snake(delay = 1)
      sprints = [ '_--_', '--__', '-__-', '__--' ]
      cycle_through sprints, delay
    end
end

SpinningCursor.start do
  banner "An amazing task is happening"
  type :snake
  delay 0.2
  action do 
    sleep 5
  end
  message "Huh?! I'm awake!"
end
```
