### PR TITLE
Fix Issue #18

### DIFF
--- a/lib/spinning_cursor.rb
+++ b/lib/spinning_cursor.rb
@@ -53,6 +53,13 @@ module SpinningCursor
   #
   def stop
     begin
+      @spinner.kill
+      # Wait for the cursor to die -- can cause problems otherwise
+      @spinner.join
+      # Set cursor to nil so set_banner method only works
+      # when cursor is actually running.
+      @cursor = nil
+
       restore_stdout_sync_status
       if console_captured?
         $console.print ESC_R_AND_CLR + $stdout.string
@@ -60,12 +67,6 @@ module SpinningCursor
       end
       show_cursor
 
-      @spinner.kill
-      # Wait for the cursor to die -- can cause problems otherwise
-      @spinner.join
-      # Set cursor to nil so set_banner method only works
-      # when cursor is actually running.
-      @cursor = nil
       reset_line
       puts @parsed.message
       # Set parsed to nil so set_message method only works

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'bundler'
 begin
-  Bundler.setup(:default, :development)
+  Bundler.setup(:default, :development, :test)
 rescue Bundler::BundlerError => e
   $stderr.puts e.message
   $stderr.puts "Run `bundle install` to install missing gems"

--- a/test/test_spinning_cursor.rb
+++ b/test/test_spinning_cursor.rb
@@ -112,11 +112,9 @@ class TestSpinningCursor < Test::Unit::TestCase
             # Have to give it time to print the banners
             sleep 0.1
             assert_equal true, (out.string.include? "Loading"), "It should initialy show default banner"
-            sleep 0.1
             SpinningCursor.set_banner "Finishing up"
-            sleep 0.2
+            sleep 0.3
             assert_equal true, (out.string.include? "Finishing up"), "It should have changed banner"
-            sleep 0.1
           end
         end
       end


### PR DESCRIPTION
Fix Issue #18.

We were releasing the console before killing the spinner.
The spinner so tries to call $stdout.string but STDOUT has no string method.
The error was not constant because most of the times the thread got killed before trying to call the string method on STDOUT.
