### PR TITLE
Yielding vs. Instance Evaluating (The Instance Variables issue)

### DIFF
--- a/lib/spinning_cursor/parser.rb
+++ b/lib/spinning_cursor/parser.rb
@@ -15,7 +15,11 @@ module SpinningCursor
 
       if block_given?
         @outer_scope_object = eval("self", block.binding)
-        instance_eval &block
+        if block.arity == 1
+          yield self
+        else
+          instance_eval &block
+        end
       end
     end
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -75,4 +75,46 @@ class TestSpinningCursorParser < Test::Unit::TestCase
       assert_equal proc, @parser.action
     end
   end
+
+  context "SpinningCursor#start" do
+    context "with a block with 1 parameter (arity 1)" do
+      setup do
+        $outer_context = self
+        capture_stdout do |out|
+          SpinningCursor.start do |param|
+            $inner_context = self
+            $yielded_param = param
+          end
+        end
+      end
+
+      should "yield the Parser as parameter" do
+        assert_equal Parser, $yielded_param.class
+      end
+
+      should "outer context be available (outer self = inner self)" do
+        assert_equal $inner_context.object_id, $outer_context.object_id
+      end
+    end
+
+    context "with a block without parameters (arity 0)" do
+      setup do
+        $outer_context = self
+        capture_stdout do |out|
+          SpinningCursor.start do
+            $inner_context = self
+          end
+        end
+      end
+
+      should "instance_eval the block on Parser context" do
+        assert_equal Parser, $inner_context.class
+      end
+
+      should "outer context NOT be available (outer self != inner self)" do
+        assert_not_equal $outer_context.object_id, $inner_context.object_id
+      end
+
+    end
+  end
 end

--- a/test/test_spinning_cursor.rb
+++ b/test/test_spinning_cursor.rb
@@ -162,4 +162,38 @@ class TestSpinningCursor < Test::Unit::TestCase
       end
     end
   end
+
+  context "SpinningCursor#start" do
+
+    context "with a block with 1 parameter (arity 1)" do
+      setup do
+        @my_inst = "outer_inst"
+        capture_stdout do |out|
+          SpinningCursor.start do |param|
+            @my_inst = "inner_inst"
+          end
+        end
+      end
+
+      should "outer instance variables be available inside" do
+        assert_equal "inner_inst", @my_inst
+      end
+    end
+
+    context "with a block without parameters (arity 0)" do
+      setup do
+        @my_inst = "outer_inst"
+        capture_stdout do |out|
+          SpinningCursor.start do
+            @my_inst = "inner_inst"
+          end
+        end
+      end
+
+      should "outer instance variables NOT be available inside" do
+        assert_equal "outer_inst", @my_inst
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
With some tips from:
- http://rubylearning.com/blog/2010/11/30/how-do-i-build-dsls-with-yield-and-instance_eval/
- http://erniemiller.org/2012/06/07/accessing-instance-variables-in-squeel-or-fun-with-bindings-and-instance_eval/

... It was easy to make the best of 2 worlds be availabe for the gem.

Now I can access intance variables outside the block with the new interface.
Below it is a perfectly working code.

``` ruby
@my_inst = "My Banner"
SpinningCursor.start do |sc|
  sc.banner @my_inst
  sc.action { sleep 2 }
end
```

The 'old' way is preserved. 
But, as before, instance variables are not available.

``` ruby
@my_inst = "My Banner"
SpinningCursor.start do
  banner @my_inst     # Here @my_inst is from Parser and it's nil
  action { sleep 2 }
end
```
