### PR TITLE
Fix Issue25

### DIFF
--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -94,6 +94,7 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
             def reset_line(str)
               $cycle_steps.push str
               $cycle_times.push Time.now
+              Thread.current.kill if $cycle_times.size == 5
             end
           end
           test_cursor.spin

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -107,6 +107,8 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
           assert (interval > delay and interval < (1.5 * delay))
         end
 
+        assert_equal ["|", "/", "-", "\\", "|"], $cycle_steps
+
         # slight delay to get things started
         sleep (delay/3.0)
         buffer =  (ESC_R_AND_CLR + "|")

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -83,9 +83,6 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
 
   context "spinner" do
     setup do
-    end
-
-    should "cycle through correctly" do
       parsed = Parser.new { type :spinner; delay 0.2; banner ""}
       delay = parsed.delay
       $cycle_steps = []
@@ -102,17 +99,18 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
           end
           test_cursor.spin
         end
-
         spinner.join
-
-        $cycle_times.each_cons(2) do |t1, t2|
-          interval = t2-t1
-          assert (interval > delay and interval < (1.5 * delay))
-        end
-
-        assert_equal ["|", "/", "-", "\\", "|"], $cycle_steps
-
       end
+    end
+
+    should "cycle through correctly" do
+
+      $cycle_times.each_cons(2) do |t1, t2|
+        interval = t2-t1
+        assert (interval > delay and interval < (1.5 * delay))
+      end
+
+      assert_equal ["|", "/", "-", "\\", "|"], $cycle_steps
     end
 
     should "changes 'frames' with correct delay" do

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -103,13 +103,14 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
       end
     end
 
-    should "cycle through correctly" do
-
+    should "change 'frames' with correct delay" do
       $cycle_times.each_cons(2) do |t1, t2|
         interval = t2-t1
         assert (interval > @delay and interval < (1.5 * @delay))
       end
+    end
 
+    should "cycle through correctly" do
       assert_equal ["|", "/", "-", "\\", "|"], $cycle_steps
     end
 

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -102,6 +102,11 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
 
         spinner.join
 
+        $cycle_times.each_cons(2) do |t1, t2|
+          interval = t2-t1
+          assert (interval > delay and interval < (1.5 * delay))
+        end
+
         # slight delay to get things started
         sleep (delay/3.0)
         buffer =  (ESC_R_AND_CLR + "|")

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -113,25 +113,5 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
     should "cycle through correctly" do
       assert_equal ["|", "/", "-", "\\", "|"], $cycle_steps
     end
-
-    should "changes 'frames' with correct delay" do
-      parsed = Parser.new { type :spinner; delay 0.2; banner ""}
-      delay = parsed.delay
-      capture_stdout do |out|
-        spinner = Thread.new do
-          SpinningCursor::Cursor.new(parsed).spin
-        end
-        sleep (delay/4.0)
-        buffer = (ESC_R_AND_CLR + "|")
-        assert_equal buffer, out.string
-        buffer += (ESC_R_AND_CLR + "/")
-        sleep delay
-        # next frame after 'delay' second
-        assert_equal buffer, out.string
-        # don't need to go through the whole thing, otherwise test will take
-        # too long
-        spinner.kill
-      end
-    end
   end
 end

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -84,7 +84,7 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
   context "spinner" do
     setup do
       parsed = Parser.new { type :spinner; delay 0.2; banner ""}
-      delay = parsed.delay
+      @delay = parsed.delay
       $cycle_steps = []
       $cycle_times = []
       capture_stdout do |out|
@@ -107,7 +107,7 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
 
       $cycle_times.each_cons(2) do |t1, t2|
         interval = t2-t1
-        assert (interval > delay and interval < (1.5 * delay))
+        assert (interval > @delay and interval < (1.5 * @delay))
       end
 
       assert_equal ["|", "/", "-", "\\", "|"], $cycle_steps

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -100,6 +100,8 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
           test_cursor.spin
         end
 
+        spinner.join
+
         # slight delay to get things started
         sleep (delay/3.0)
         buffer =  (ESC_R_AND_CLR + "|")

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -85,10 +85,20 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
     should "cycle through correctly" do
       parsed = Parser.new { type :spinner; delay 0.2; banner ""}
       delay = parsed.delay
+      $cycle_steps = []
+      $cycle_times = []
       capture_stdout do |out|
         spinner = Thread.new do
-          SpinningCursor::Cursor.new(parsed).spin
+          test_cursor = SpinningCursor::Cursor.new(parsed)
+          class << test_cursor
+            def reset_line(str)
+              $cycle_steps.push str
+              $cycle_times.push Time.now
+            end
+          end
+          test_cursor.spin
         end
+
         # slight delay to get things started
         sleep (delay/3.0)
         buffer =  (ESC_R_AND_CLR + "|")

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -82,6 +82,9 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
   end
 
   context "spinner" do
+    setup do
+    end
+
     should "cycle through correctly" do
       parsed = Parser.new { type :spinner; delay 0.2; banner ""}
       delay = parsed.delay

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -109,23 +109,6 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
 
         assert_equal ["|", "/", "-", "\\", "|"], $cycle_steps
 
-        # slight delay to get things started
-        sleep (delay/3.0)
-        buffer =  (ESC_R_AND_CLR + "|")
-        assert_equal buffer, out.string
-        buffer += (ESC_R_AND_CLR + "/")
-        sleep delay
-        assert_equal buffer, out.string
-        buffer += (ESC_R_AND_CLR + "-")
-        sleep delay
-        assert_equal buffer, out.string
-        buffer += (ESC_R_AND_CLR + "\\")
-        sleep delay
-        assert_equal buffer, out.string
-        sleep delay
-        buffer += (ESC_R_AND_CLR + "|")
-        assert_equal buffer, out.string
-        spinner.kill
       end
     end
 


### PR DESCRIPTION
Test was refactored not to depend on "timing" and not to be too influenced by the threads particularities.
Now the test has a fake "reset_line" method that keep tracks of what is being "reseted" and when.
So we can test if the cycle_through method is yielding the right characters and at the (almost) correct time.
The test admists delay to be between 1 - 1.5 x the programed delay. So this makes the test more 'resistent' to the case when thread for some issue is being delayed more than the programed. But still fails if the delay is too different (>1.5x) of the programed.
