### PR TITLE
Fix Issue #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ _It's so simple it hurts!_
 ```ruby
 require 'spinning_cursor' # you'll definitely need this bit
 
-SpinningCursor.start do
+SpinningCursor.run do
   banner "An amazing task is happening"
   type :spinner
   action do
@@ -76,7 +76,7 @@ The first option is the simplest, but the second isn't so bad either.
 It's pretty simple, just do:
 
 ```ruby
-SpinningCursor.start do
+SpinningCursor.run do
   banner "Loading"
   type :dots
   message "Done"
@@ -88,7 +88,7 @@ sleep 20
 SpinningCursor.stop
 ```
 
-**Notice** the absence of the `action` option. The start method will only keep
+**Notice** the absence of the `action` option. The run method will only keep
 the cursor running if an `action` block isn't passed to it.
 
 ### I want to be able to change the finish message conditionally!
@@ -98,7 +98,7 @@ Do you? Well that's easy too (I'm starting to see a pattern here...)!
 Use the `set_message` method to change the message during the execution:
 
 ```ruby
-SpinningCursor.start do
+SpinningCursor.run do
   banner "Calculating your favour colour, please wait"
   type :dots
   action do
@@ -123,7 +123,7 @@ the banner message in the same way you would the finish message, using
 `set_banner`:
 
 ```ruby
-SpinningCursor.start do
+SpinningCursor.run do
   banner "Stealing your food"
   action do
     sleep 10

--- a/lib/spinning_cursor.rb
+++ b/lib/spinning_cursor.rb
@@ -47,6 +47,8 @@ module SpinningCursor
     end
   end
 
+  alias run start
+
   #
   # Kills the cursor thread and prints the finished message
   # Returns execution time

--- a/lib/spinning_cursor.rb
+++ b/lib/spinning_cursor.rb
@@ -8,20 +8,30 @@ module SpinningCursor
   include self::ConsoleHelpers
   extend  self::ConsoleHelpers
 
+  def setup(&block)
+    @parsed = Parser.new(&block)
+    @cursor = Cursor.new(@parsed)
+    @setup = true
+    self
+  end
+
+  def setup?
+    @setup
+  end
+
   #
   # Sends passed block to Parser, and starts cursor thread
   # It will execute the action block and kill the cursor
   # thread if an action block is passed.
   #
   def start(&block)
+    setup(&block) if block or not setup?
     stop if alive?
 
     save_stdout_sync_status
     capture_console
     hide_cursor
 
-    @parsed = Parser.new(&block)
-    @cursor = Cursor.new(@parsed)
     @spinner = Thread.new do
       abort_on_exception = true
       @cursor.spin
@@ -74,6 +84,7 @@ module SpinningCursor
       # Set parsed to nil so set_message method only works
       # when cursor is actually running.
       @parsed = nil
+      @setup = false
 
       # Return execution time
       @stop_watch.stop

--- a/lib/spinning_cursor/parser.rb
+++ b/lib/spinning_cursor/parser.rb
@@ -44,11 +44,30 @@ module SpinningCursor
     #   For setting, use method with arguments
     #   e.g. `banner "my banner"`
     #
-    %w[banner type message delay output].each do |method|
+
+    methods_and_validations = {
+      :type    => Proc.new { |arg|
+        inst_methods = SpinningCursor::Cursor.public_instance_methods |
+                       SpinningCursor::Cursor.private_instance_methods |
+                       SpinningCursor::Cursor.protected_instance_methods
+        inst_methods.include?(arg) ? arg : false },
+      :delay   => Proc.new { |arg| arg.is_a?(Numeric) ? arg.to_f : false},
+      :output  => Proc.new { |arg| [:inline, :at_stop].include?(arg) ? arg : false},
+      :banner  => Proc.new { |arg| arg.respond_to?(:to_s) ? arg.to_s : false},
+      :message => Proc.new { |arg| arg.respond_to?(:to_s) ? arg.to_s : false},
+    }
+
+    methods_and_validations.each do |method, validation|
       define_method(method) do |*args|
         var = "@#{method}"
-        return instance_variable_get(var) unless args.first
-        instance_variable_set(var, args.first)
+        arg = args.first
+        if arg
+          valid_arg = validation.call(arg)
+          raise ArgumentError unless valid_arg
+          instance_variable_set(var, valid_arg)
+        else
+          instance_variable_get(var)
+        end
       end
     end
 

--- a/lib/spinning_cursor/parser.rb
+++ b/lib/spinning_cursor/parser.rb
@@ -50,7 +50,7 @@ module SpinningCursor
         inst_methods = SpinningCursor::Cursor.public_instance_methods |
                        SpinningCursor::Cursor.private_instance_methods |
                        SpinningCursor::Cursor.protected_instance_methods
-        inst_methods.include?(arg) ? arg : false },
+        (inst_methods & [ arg, arg.to_s ]).empty? ? false : arg },
       :delay   => Proc.new { |arg| arg.is_a?(Numeric) ? arg.to_f : false},
       :output  => Proc.new { |arg| [:inline, :at_stop].include?(arg) ? arg : false},
       :banner  => Proc.new { |arg| arg.respond_to?(:to_s) ? arg.to_s : false},

--- a/test/test_cursors.rb
+++ b/test/test_cursors.rb
@@ -8,7 +8,7 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
     should "not clear lines above if it fits within the width of the shell" do
       # general case
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           banner (1..cols-20).map { ('a'..'z').to_a[rand(26)] }.join
           action { sleep 0.1 }
         end
@@ -18,7 +18,7 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
 
     should "not clear lines above if it fits exactly on the line (edge case)" do
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           # spinner type takes up two characters, so minus 2 to fit exactly
           banner (1..cols-2).map { ('a'..'z').to_a[rand(26)] }.join
           action { sleep 0.1 }
@@ -29,7 +29,7 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
 
     should "clear lines above if banner message overflows" do
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           # spinner type takes up two characters, so minus 2 to fit exactly
           banner (1..400).map { ('a'..'z').to_a[rand(26)] }.join
           action { sleep 0.1 }
@@ -40,7 +40,7 @@ class TestSpinningCursorCursor < Test::Unit::TestCase
 
     should "clear lines above if banner message overflows (edge case)" do
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           # spinner type takes up two characters, so minus 2 to fit exactly
           banner (1..cols-1).map { ('a'..'z').to_a[rand(26)] }.join
           action { sleep 0.1 }

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -144,5 +144,23 @@ class TestSpinningCursorParser < Test::Unit::TestCase
         assert_nothing_raised { SpinningCursor::Parser.new.output :at_stop }
       end
     end
+    context "'banner' and 'message'" do
+      class LackingToSClass
+        undef :to_s
+      end
+
+      should "raise ArgumentError if argument IS NOT a String nor respond_to :to_s (:banner)" do
+        assert_raise(ArgumentError) { SpinningCursor::Parser.new.banner LackingToSClass.new }
+      end
+      should "raise ArgumentError if argument IS NOT a String nor respond_to :to_s (:message)" do
+        assert_raise(ArgumentError) { SpinningCursor::Parser.new.message LackingToSClass.new }
+      end
+      should "NOT raise anything if argument IS a String or respond_to :to_s (:banner)" do
+        assert_nothing_raised { SpinningCursor::Parser.new.banner "A String" }
+      end
+      should "NOT raise anything if argument IS a String or respond_to :to_s (:message)" do
+        assert_nothing_raised { SpinningCursor::Parser.new.message "A String" }
+      end
+    end
   end
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -135,5 +135,14 @@ class TestSpinningCursorParser < Test::Unit::TestCase
         assert_nothing_raised { SpinningCursor::Parser.new.delay 10 }
       end
     end
+    context "'output'" do
+      should "raise ArgumentError if argument IS NOT :inline or :at_stop" do
+        assert_raise(ArgumentError) { SpinningCursor::Parser.new.output :not_inline_nor_at_stop }
+      end
+      should "NOT raise anything if argument IS :inline or :at_stop" do
+        assert_nothing_raised { SpinningCursor::Parser.new.output :inline }
+        assert_nothing_raised { SpinningCursor::Parser.new.output :at_stop }
+      end
+    end
   end
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -117,4 +117,15 @@ class TestSpinningCursorParser < Test::Unit::TestCase
 
     end
   end
+
+  context "SpinningCursor::Parser method" do
+    context "'type'" do
+      should "raise ArgumentError if argument IS NOT a SpinningCursor::Cursor instance_method" do
+        assert_raise(ArgumentError) { SpinningCursor::Parser.new.type :fake_method }
+      end
+      should "NOT raise anything if argument IS a SpinningCursor::Cursor instance_method" do
+        assert_nothing_raised { SpinningCursor::Parser.new.type :dots }
+      end
+    end
+  end
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -127,5 +127,13 @@ class TestSpinningCursorParser < Test::Unit::TestCase
         assert_nothing_raised { SpinningCursor::Parser.new.type :dots }
       end
     end
+    context "'delay'" do
+      should "raise ArgumentError if argument IS NOT a Numeric" do
+        assert_raise(ArgumentError) { SpinningCursor::Parser.new.delay "Not a number" }
+      end
+      should "NOT raise anything if argument IS a Numeric" do
+        assert_nothing_raised { SpinningCursor::Parser.new.delay 10 }
+      end
+    end
   end
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -76,12 +76,12 @@ class TestSpinningCursorParser < Test::Unit::TestCase
     end
   end
 
-  context "SpinningCursor#start" do
+  context "SpinningCursor#run" do
     context "with a block with 1 parameter (arity 1)" do
       setup do
         $outer_context = self
         capture_stdout do |out|
-          SpinningCursor.start do |param|
+          SpinningCursor.run do |param|
             $inner_context = self
             $yielded_param = param
           end
@@ -101,7 +101,7 @@ class TestSpinningCursorParser < Test::Unit::TestCase
       setup do
         $outer_context = self
         capture_stdout do |out|
-          SpinningCursor.start do
+          SpinningCursor.run do
             $inner_context = self
           end
         end

--- a/test/test_spinning_cursor.rb
+++ b/test/test_spinning_cursor.rb
@@ -196,4 +196,43 @@ class TestSpinningCursor < Test::Unit::TestCase
     end
   end
 
+  context "SpinningCursor#setup" do
+    setup do
+      @sc = SpinningCursor.setup do
+        banner "My Setup Banner"
+        type :dots
+        message "My Setup Message"
+        delay 0.73
+        @bl = Proc.new {}
+        action(&@bl)
+        output :at_stop
+      end
+      @parsed = @sc.instance_variable_get(:@parsed)
+    end
+
+    should "parse banner correctly" do
+      assert_equal "My Setup Banner", @parsed.banner
+    end
+
+    should "parse type correctly" do
+      assert_equal :dots, @parsed.type
+    end
+
+    should "parse message correctly" do
+      assert_equal "My Setup Message", @parsed.message
+    end
+
+    should "parse delay correctly" do
+      assert_equal 0.73, @parsed.delay
+    end
+
+    should "parse action correctly" do
+      assert_equal @parsed.instance_variable_get(:@bl), @parsed.action
+    end
+
+    should "parse output correctly" do
+      assert_equal :at_stop, @parsed.output
+    end
+  end
+
 end

--- a/test/test_spinning_cursor.rb
+++ b/test/test_spinning_cursor.rb
@@ -5,7 +5,7 @@ class TestSpinningCursor < Test::Unit::TestCase
     should "start the cursor, run block content and kill the cursor" do
       # Hide any output
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           action { sleep 0.1 }
         end
         # Give it some time to abort
@@ -15,7 +15,7 @@ class TestSpinningCursor < Test::Unit::TestCase
 
     should "Parser#outer_scope_object point to 'caller'" do
       capture_stdout do |out|
-        SpinningCursor.start { }
+        SpinningCursor.run { }
         parsed = SpinningCursor.instance_variable_get(:@parsed)
         assert_equal self, parsed.outer_scope_object
         SpinningCursor.stop
@@ -25,7 +25,7 @@ class TestSpinningCursor < Test::Unit::TestCase
     should "evalute the block from the calling class" do
       @num = 1
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           action { @num += 1 }
         end
 
@@ -37,7 +37,7 @@ class TestSpinningCursor < Test::Unit::TestCase
       class SomethingWrongHappened < StandardError; end
       assert_raise SomethingWrongHappened do
         capture_stdout do |out|
-          SpinningCursor.start do
+          SpinningCursor.run do
             action { raise SomethingWrongHappened }
           end
         end
@@ -48,7 +48,7 @@ class TestSpinningCursor < Test::Unit::TestCase
   context "when an action block isn't passed it" do
     should "start the cursor, and keep it going until stop is called" do
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           banner "no action block"
         end
         sleep 0.5
@@ -63,7 +63,7 @@ class TestSpinningCursor < Test::Unit::TestCase
   context "whilst running it" do
     should "allow you to change the end message" do
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           action do
             SpinningCursor.set_message "Failed!"
           end
@@ -77,7 +77,7 @@ class TestSpinningCursor < Test::Unit::TestCase
     should "stop and display error if an unmanaged exception is thrown" do
       capture_stdout do |out|
         begin
-          SpinningCursor.start do
+          SpinningCursor.run do
             action do
               raise "An exception!"
             end
@@ -90,7 +90,7 @@ class TestSpinningCursor < Test::Unit::TestCase
 
     should "not stop if an exception is handled" do
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           action do
             begin
               raise "An exception!"
@@ -106,7 +106,7 @@ class TestSpinningCursor < Test::Unit::TestCase
 
     should "allow you to change the banner" do
       capture_stdout do |out|
-        SpinningCursor.start do
+        SpinningCursor.run do
           delay 0.2
           action do
             # Have to give it time to print the banners
@@ -142,7 +142,7 @@ class TestSpinningCursor < Test::Unit::TestCase
     should "(with a block) return similar timing values" do
       capture_stdout do |out|
         result =
-        SpinningCursor.start do
+        SpinningCursor.run do
           action do
             sleep 0.2
           end
@@ -150,7 +150,7 @@ class TestSpinningCursor < Test::Unit::TestCase
         timing_1 = result[:elapsed_time]
 
         result =
-        SpinningCursor.start do
+        SpinningCursor.run do
           action do
             sleep 0.2
           end
@@ -163,13 +163,13 @@ class TestSpinningCursor < Test::Unit::TestCase
     end
   end
 
-  context "SpinningCursor#start" do
+  context "SpinningCursor#run" do
 
     context "with a block with 1 parameter (arity 1)" do
       setup do
         @my_inst = "outer_inst"
         capture_stdout do |out|
-          SpinningCursor.start do |param|
+          SpinningCursor.run do |param|
             @my_inst = "inner_inst"
           end
         end
@@ -184,7 +184,7 @@ class TestSpinningCursor < Test::Unit::TestCase
       setup do
         @my_inst = "outer_inst"
         capture_stdout do |out|
-          SpinningCursor.start do
+          SpinningCursor.run do
             @my_inst = "inner_inst"
           end
         end


### PR DESCRIPTION
Fix Issue #14
Related to https://github.com/prydonius/spinning_cursor/issues/12#issuecomment-20354890

Now we can do like this.

``` Ruby
@num = 1
sc = SpinningCursor.setup do
  banner "My banner"
  type :spinner
  delay 0.5
end

sc.start
@num += 1
sc.stop

# Now @num == 2 and the code make it clear that the @num instance variables are the same.
```
